### PR TITLE
Feature/connector write

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nsoft/chameleon-sdk",
-  "version": "1.0.101",
+  "version": "1.0.102-beta.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nsoft/chameleon-sdk",
-  "version": "1.0.2-beta.4",
+  "version": "1.0.102-beta.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nsoft/chameleon-sdk",
-  "version": "1.0.102-beta.2",
+  "version": "1.0.102-beta.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7806,9 +7806,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.14",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
-      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw=="
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
     "lodash.sortby": {
       "version": "4.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nsoft/chameleon-sdk",
-  "version": "1.0.102-beta.4",
+  "version": "1.0.102",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nsoft/chameleon-sdk",
-  "version": "1.0.102-beta.3",
+  "version": "1.0.102-beta.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -7806,9 +7806,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lodash.sortby": {
       "version": "4.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nsoft/chameleon-sdk",
-  "version": "1.0.102-beta.1",
+  "version": "1.0.2-beta.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nsoft/chameleon-sdk",
-  "version": "1.0.102-beta.1",
+  "version": "1.0.102-beta.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nsoft/chameleon-sdk",
-  "version": "1.0.102-beta.0",
+  "version": "1.0.102-beta.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nsoft/chameleon-sdk",
-  "version": "1.0.102-beta.1",
+  "version": "1.0.102-beta.2",
   "description": "Chameleon Software Development Kit",
   "author": "Chameleon Team <chameleon@nsoft.com>",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nsoft/chameleon-sdk",
-  "version": "1.0.2-beta.4",
+  "version": "1.0.102-beta.4",
   "description": "Chameleon Software Development Kit",
   "author": "Chameleon Team <chameleon@nsoft.com>",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "axios": "^0.19.0",
     "date-fns": "^2.0.0-alpha.27",
-    "lodash": "^4.17.14"
+    "lodash": "4.17.11"
   },
   "devDependencies": {
     "@babel/cli": "^7.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nsoft/chameleon-sdk",
-  "version": "1.0.102-beta.1",
+  "version": "1.0.102-beta.3",
   "description": "Chameleon Software Development Kit",
   "author": "Chameleon Team <chameleon@nsoft.com>",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nsoft/chameleon-sdk",
-  "version": "1.0.102-beta.4",
+  "version": "1.0.102",
   "description": "Chameleon Software Development Kit",
   "author": "Chameleon Team <chameleon@nsoft.com>",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nsoft/chameleon-sdk",
-  "version": "1.0.102-beta.0",
+  "version": "1.0.102-beta.1",
   "description": "Chameleon Software Development Kit",
   "author": "Chameleon Team <chameleon@nsoft.com>",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nsoft/chameleon-sdk",
-  "version": "1.0.101",
+  "version": "1.0.102-beta.0",
   "description": "Chameleon Software Development Kit",
   "author": "Chameleon Team <chameleon@nsoft.com>",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nsoft/chameleon-sdk",
-  "version": "1.0.102-beta.3",
+  "version": "1.0.102-beta.1",
   "description": "Chameleon Software Development Kit",
   "author": "Chameleon Team <chameleon@nsoft.com>",
   "contributors": [
@@ -26,7 +26,7 @@
   "dependencies": {
     "axios": "^0.19.0",
     "date-fns": "^2.0.0-alpha.27",
-    "lodash": "4.17.11"
+    "lodash": "^4.17.14"
   },
   "devDependencies": {
     "@babel/cli": "^7.5.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "eslint-config-airbnb-base": "^13.0.0",
     "eslint-friendly-formatter": "^4.0.1",
     "eslint-plugin-import": "^2.17.1",
-    "jest": "^24.7.1",
+    "jest": "^24.8.0",
     "jest-localstorage-mock": "^2.4.0",
     "uuid": "^3.3.2",
     "vue": "^2.6.3",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint": "eslint --ext .js,.vue src",
     "test": "npm run lint && jest",
     "coverage": "npm test && codecov",
-    "prepublish": "npm test && npm run build"
+    "prepare": "npm test && npm run build"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nsoft/chameleon-sdk",
-  "version": "1.0.102-beta.3",
+  "version": "1.0.2-beta.4",
   "description": "Chameleon Software Development Kit",
   "author": "Chameleon Team <chameleon@nsoft.com>",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nsoft/chameleon-sdk",
-  "version": "1.0.102-beta.2",
+  "version": "1.0.102-beta.3",
   "description": "Chameleon Software Development Kit",
   "author": "Chameleon Team <chameleon@nsoft.com>",
   "contributors": [

--- a/src/api/connector/index.js
+++ b/src/api/connector/index.js
@@ -1,6 +1,7 @@
-import { assign } from 'lodash';
+import { assign, isFunction } from 'lodash';
 import * as internalTypes from './internal';
 import * as externalTypes from './external';
+import { logger } from '../../utility';
 
 const connectorTypes = assign({}, internalTypes, externalTypes);
 
@@ -49,7 +50,13 @@ export default {
     Action is used to differentiate methods on connector backend API.
     */
   changeSourceData(connector, source, options = {}) {
-    const connectorType = this.getConnectorType(connector);
+    const connectorType = this.getConnectorType(connector.type);
+
+    if (!isFunction(connectorType.changeSourceData)) {
+      const message = `Changing source data is not supported on ${connector.name} connector`;
+      logger.error(message);
+      return Promise.reject(message);
+    }
 
     return connectorType.changeSourceData(connector, source, options).then((data) => {
       const result = parseChangeSourceData(connector, source, options, data);

--- a/src/api/connector/internal/graphql.js
+++ b/src/api/connector/internal/graphql.js
@@ -121,9 +121,6 @@ const getSourceModel = (source) => {
 };
 
 export default {
-  changeSourceData(connector) {
-    throw new Error(`Method changeSourceData is not implemented on ${connector.name} connector!`);
-  },
   getSources(connector, { savedOnly }) {
     if (savedOnly) return getSavedSources(connector);
 

--- a/src/api/connector/internal/rest.js
+++ b/src/api/connector/internal/rest.js
@@ -93,7 +93,8 @@ const getChangePayload = (payload, schema) => {
   each(payload, (value, key) => {
     const schemaField = find(schema, { mapName: key });
 
-    const fieldValue = schemaField.type === 'number' ? parseFloat(value) : value;
+    const fieldValue = schemaField.type === 'number' && value
+      ? parseFloat(value) : value;
     change[schemaField.displayFieldId] = fieldValue;
   });
 
@@ -252,7 +253,10 @@ export default {
     }
 
     return http[method](url, payload).then((response) => {
-      const result = response.data;
+      // return result with field names from original payload
+      const result = options.payload;
+      result.id = response.data.recordInstanceId;
+
       return result;
     });
   },

--- a/src/api/connector/internal/rest.js
+++ b/src/api/connector/internal/rest.js
@@ -91,8 +91,10 @@ const getChangePayload = (payload, schema) => {
   const change = {};
 
   each(payload, (value, key) => {
-    const schemaField = find(schema, { name: key });
-    change[schemaField.id] = value;
+    const schemaField = find(schema, { mapName: key });
+
+    const fieldValue = schemaField.type === 'number' ? parseFloat(value) : value;
+    change[schemaField.displayFieldId] = fieldValue;
   });
 
   return change;
@@ -242,8 +244,8 @@ export default {
   changeSourceData(connector, source, options) {
     const baseUrl = getBaseUrl(connector.options, connector.type, 'write');
     const method = getChangeMethod(options);
-    const payload = getChangePayload(options.payload, options.schema);
-    let url = `${baseUrl}/schema-versions/${source.schemaVersion}/records/${source.record}`;
+    const payload = getChangePayload(options.payload, source.schema);
+    let url = `${baseUrl}/schema-versions/${source.meta.schemaVersion}/records/${source.meta.record}`;
 
     if (payload.recordInstanceId) {
       url += `/instances/${payload.recordInstanceId}`;

--- a/src/api/connector/internal/rest.spec.js
+++ b/src/api/connector/internal/rest.spec.js
@@ -34,6 +34,32 @@ const sourceMock = {
   filters: [
     {},
   ],
+  schema: [
+    {
+      displayFieldId: 'a3a0ed17-0292-41ab-8485-3d77c7919e79',
+      displayName: 'name',
+      id: '7142243f-5de5-4a6a-ad0f-e33c4ec1c09e',
+      mapName: 'field-1',
+      mapType: null,
+      mask: null,
+      name: 'name',
+      recordId: 'cf758676-bf3d-40bc-9214-166c48284c13',
+      title: null,
+      type: 'text',
+    },
+    {
+      displayFieldId: '3c14b367-47c2-4d8f-a52e-2e5f2c4d9cbd',
+      displayName: 'address',
+      id: '14a1ca2a-3985-4ec9-9a97-b5f96e527a3d',
+      mapName: 'field-2',
+      mapType: null,
+      mask: null,
+      name: 'address',
+      recordId: 'cf758676-bf3d-40bc-9214-166c48284c13',
+      title: null,
+      type: 'text',
+    },
+  ],
 };
 
 describe('internal rest connector', () => {
@@ -97,6 +123,30 @@ describe('internal rest connector', () => {
           items: expect.any(Array),
           pagination: expect.any(Object),
         }),
+      });
+
+      expect(result).toEqual(expectedResult);
+      done();
+    });
+  });
+
+  it('should create new source record instance', (done) => {
+    axiosMock.post.mockImplementation(() => Promise.resolve({
+      data: { recordInstanceId: 'b086fb68-6805-46d2-838a-4d1c10862a00' },
+    }));
+
+    const options = {
+      payload: {
+        'field-1': 'Borg',
+        'field-2': 'The Cube',
+      },
+    };
+
+    rest.changeSourceData(connectorMock, sourceMock, options).then((result) => {
+      const expectedResult = expect.objectContaining({
+        'field-1': 'Borg',
+        'field-2': 'The Cube',
+        id: expect.any(String),
       });
 
       expect(result).toEqual(expectedResult);

--- a/src/mixins/sourceable.js
+++ b/src/mixins/sourceable.js
@@ -103,5 +103,17 @@ export default {
       const { schema } = this.dataSource;
       return mapping.mapWithSchema(schema, items);
     },
+    saveConnectorData(data) {
+      const connector = this.getMergedConnector();
+      const source = this.getMergedSource(connector);
+      const params = this.getMergedDataSourceParams();
+      params.payload = data;
+
+      return this.options.connector.changeSourceData(
+        connector,
+        source,
+        params,
+      ).then(response => response);
+    },
   },
 };


### PR DESCRIPTION
- Added check for `changeDataSource` method to common connector entry point
- Changed how is payload handled in internal rest connector inside `changeSourceData`
- Added `saveConnectorData` implementation to sourceable mixin.

Notes:
- this is not a breaking change
- payload mapping with source schema is done inside connector handler (instead in sourceable mixin) due to possible specifics in handling (e.g. internal rest connector uses `displayFieldId`)
- `changeSourceData` return value is initial payload merged with created `recordInstanceId`
- this PR doesn't cover record update, further discussion related to this along with dynamic parameters is needed.