### PR TITLE
Feature/bundle injector

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nsoft/chameleon-sdk",
-  "version": "1.0.107",
+  "version": "1.0.108",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nsoft/chameleon-sdk",
-  "version": "1.0.107",
+  "version": "1.0.108",
   "description": "Chameleon Software Development Kit",
   "author": "Chameleon Team <chameleon@nsoft.com>",
   "contributors": [

--- a/src/utility/bundleInjector.js
+++ b/src/utility/bundleInjector.js
@@ -1,4 +1,4 @@
-import { filter, map } from 'lodash';
+import { filter, map, indexOf } from 'lodash';
 
 const isGlobalAvailable = global => !!window[global];
 
@@ -50,7 +50,7 @@ export default {
   /**
     * Load bundles method.
     * @param {object} config - Config object width properties:
-    * scriptType, baseURL, styles, scripts.
+    * scriptTypes, baseURL, styles.
     * @param {object} bundle - Bundle object that contains bundle information.
     * @return {object} promise.
     */
@@ -60,10 +60,10 @@ export default {
     let styles = [];
 
     if (bundle.scripts) {
-      scripts = filter(bundle.scripts, script => script.type === config.scriptType);
+      scripts = filter(bundle.scripts, script => indexOf(config.scriptTypes, script.type) > -1);
     }
 
-    if (scripts.length > 0 && config.scripts) {
+    if (scripts.length > 0) {
       promises = map(scripts, script => addBundleItem(script, 'script', bundle.name, config.baseURL));
     }
 

--- a/src/utility/bundleInjector.js
+++ b/src/utility/bundleInjector.js
@@ -48,14 +48,6 @@ const addBundleItem = (item, type, bundleName, bundleBaseUrl) => {
 
 export default {
   loadBundles(config) {
-    // config example
-    // const config = {
-    //   bundle: bundle,
-    //   scriptType: 'meta',
-    //   baseURL: process.env.VUE_APP_ASSETS_BASEURL,
-    //   style: false,
-    //   script: true
-    // };
     let scripts = [];
     let promises = [];
     let styles = [];

--- a/src/utility/bundleInjector.js
+++ b/src/utility/bundleInjector.js
@@ -5,7 +5,7 @@ const isGlobalAvailable = global => !!window[global];
 const startAvailabilityInterval = (global, resolve) => {
   const availabilityInterval = setInterval(() => {
     if (isGlobalAvailable(global)) {
-      resolve();
+      resolve(global);
       clearInterval(availabilityInterval);
     }
   }, 100);
@@ -70,8 +70,9 @@ export default {
 
     if (config.bundle.styles && config.style) {
       styles = map(config.bundle.styles, style => addBundleItem(style, 'link', config.bundle.name, config.baseURL));
-      promises = promises.concat(styles);
     }
+
+    promises = promises.concat(styles);
 
     return Promise.all(promises);
   },

--- a/src/utility/bundleInjector.js
+++ b/src/utility/bundleInjector.js
@@ -1,0 +1,78 @@
+import { filter, map } from 'lodash';
+
+const isGlobalAvailable = global => !!window[global];
+
+const startAvailabilityInterval = (global, resolve) => {
+  const availabilityInterval = setInterval(() => {
+    if (isGlobalAvailable(global)) {
+      resolve();
+      clearInterval(availabilityInterval);
+    }
+  }, 100);
+
+  return availabilityInterval;
+};
+
+const addBundleItem = (item, type, bundleName, bundleBaseUrl) => {
+  const attr = type === 'script' ? 'src' : 'href';
+  const itemName = type === 'script' ? item.script : item;
+  const itemGlobal = item.global;
+  let checkInterval = null;
+
+  const script = document.createElement(type);
+  script.setAttribute(attr, `${bundleBaseUrl}/bundles/${bundleName}/latest/${itemName}`);
+
+  if (type === 'script') {
+    document.body.appendChild(script);
+  } else {
+    script.rel = 'stylesheet';
+    script.type = 'text/css';
+    document.head.appendChild(script);
+  }
+
+  return new Promise((resolve, reject) => {
+    script.onload = () => {
+      if (type === 'link' || isGlobalAvailable(itemGlobal)) {
+        resolve(itemGlobal);
+      } else {
+        checkInterval = startAvailabilityInterval(itemGlobal, resolve);
+      }
+    };
+
+    script.onerror = () => {
+      if (checkInterval) clearInterval(checkInterval);
+      reject(bundleName);
+    };
+  });
+};
+
+export default {
+  loadBundles(config) {
+    // config example
+    // const config = {
+    //   bundle: bundle,
+    //   scriptType: 'meta',
+    //   baseURL: process.env.VUE_APP_ASSETS_BASEURL,
+    //   style: false,
+    //   script: true
+    // };
+    let scripts = [];
+    let promises = [];
+    let styles = [];
+
+    if (config.bundle.scripts) {
+      scripts = filter(config.bundle.scripts, script => script.type === config.scriptType);
+    }
+
+    if (scripts.length > 0 && config.script) {
+      promises = map(scripts, script => addBundleItem(script, 'script', config.bundle.name, config.baseURL));
+    }
+
+    if (config.bundle.styles && config.style) {
+      styles = map(config.bundle.styles, style => addBundleItem(style, 'link', config.bundle.name, config.baseURL));
+      promises = promises.concat(styles);
+    }
+
+    return Promise.all(promises);
+  },
+};

--- a/src/utility/bundleInjector.js
+++ b/src/utility/bundleInjector.js
@@ -49,18 +49,18 @@ const addBundleItem = (item, type, bundleName, bundleBaseUrl) => {
 export default {
   /**
     * Load bundles method.
-    * @param {object} config - Config object width properties:
-    * scriptTypes, baseURL, styles.
     * @param {object} bundle - Bundle object that contains bundle information.
+    * @param {object} config - Config object width properties:
+    * scripts, baseURL, styles.
     * @return {object} promise.
     */
-  loadBundles(config, bundle) {
+  loadBundles(bundle, config) {
     let scripts = [];
     let promises = [];
     let styles = [];
 
     if (bundle.scripts) {
-      scripts = filter(bundle.scripts, script => indexOf(config.scriptTypes, script.type) > -1);
+      scripts = filter(bundle.scripts, script => indexOf(config.scripts, script.type) > -1);
     }
 
     if (scripts.length > 0) {

--- a/src/utility/bundleInjector.js
+++ b/src/utility/bundleInjector.js
@@ -47,21 +47,28 @@ const addBundleItem = (item, type, bundleName, bundleBaseUrl) => {
 };
 
 export default {
-  loadBundles(config) {
+  /**
+    * Load bundles method.
+    * @param {object} config - Config object width properties:
+    * scriptType, baseURL, styles, scripts.
+    * @param {object} bundle - Bundle object that contains bundle information.
+    * @return {object} promise.
+    */
+  loadBundles(config, bundle) {
     let scripts = [];
     let promises = [];
     let styles = [];
 
-    if (config.bundle.scripts) {
-      scripts = filter(config.bundle.scripts, script => script.type === config.scriptType);
+    if (bundle.scripts) {
+      scripts = filter(bundle.scripts, script => script.type === config.scriptType);
     }
 
-    if (scripts.length > 0 && config.script) {
-      promises = map(scripts, script => addBundleItem(script, 'script', config.bundle.name, config.baseURL));
+    if (scripts.length > 0 && config.scripts) {
+      promises = map(scripts, script => addBundleItem(script, 'script', bundle.name, config.baseURL));
     }
 
-    if (config.bundle.styles && config.style) {
-      styles = map(config.bundle.styles, style => addBundleItem(style, 'link', config.bundle.name, config.baseURL));
+    if (bundle.styles && config.styles) {
+      styles = map(bundle.styles, style => addBundleItem(style, 'link', bundle.name, config.baseURL));
     }
 
     promises = promises.concat(styles);

--- a/src/utility/index.js
+++ b/src/utility/index.js
@@ -1,4 +1,5 @@
 export { default as binding } from './binding';
+export { default as bundleInjector } from './bundleInjector';
 export { default as localStorage } from './localStorage';
 export { default as logger } from './logger';
 export { default as mapping } from './mapping';


### PR DESCRIPTION
Create bundleInjector utility.
There are two parameters in loadBundles method:
**1. Config**
 Example:
```
const config = {
    scriptType: 'meta',
    baseURL: process.env.VUE_APP_ASSETS_BASEURL,
    styles: false,
    scripts: true
};
```
1. scriptType could be ```components``` or ```meta```. Builder imports only meta scripts, while other two projects import only components scripts.
2. baseURL, only vue-cli-plugin doesn't have it so it should be an empty string ```baseURL: ''```. For other two it should be ```baseURL: process.env.VUE_APP_ASSETS_BASEURL```
3. styles - boolean value, inject all or no style sheets.
4. scripts - boolean value, inject all or no scripts

**2. Bundle** 
Object that contains all bundle information.

Example of the config object passed as a parameter in builder actions.js :
```
const config = {
    scriptType: 'meta',
    baseURL: process.env.VUE_APP_ASSETS_BASEURL,
    style: false,
    script: true
};
const bundlePromise = bundleInjector.loadBundles(config, bundle).then(() => {...
```
Ref https://github.com/nsftx/chameleon-sdk/issues/20
